### PR TITLE
🪄 Sysvar account used detector

### DIFF
--- a/language-server/src/backend.rs
+++ b/language-server/src/backend.rs
@@ -1,6 +1,7 @@
 use crate::core::{
     DetectorInfo, DetectorRegistry, FileScanner, ManualLamportsZeroingDetector,
     MissingSignerDetector, ScanCompleteNotification, ScanResult, ScanSummary,
+    SysvarAccountDetector,
 };
 use log::info;
 use std::sync::Arc;
@@ -305,5 +306,6 @@ fn create_default_registry() -> DetectorRegistry {
         .with_detector(UnsafeMathDetector::new())
         .with_detector(MissingSignerDetector::new())
         .with_detector(ManualLamportsZeroingDetector::new())
+        .with_detector(SysvarAccountDetector::new())
         .build()
 }

--- a/language-server/src/core/detectors/missing_signer.rs
+++ b/language-server/src/core/detectors/missing_signer.rs
@@ -1,8 +1,8 @@
 use super::detector::Detector;
 use super::detector_config::DetectorConfig;
-use crate::core::utilities::DiagnosticBuilder;
+use crate::core::utilities::{DiagnosticBuilder, anchor_patterns::AnchorPatterns};
 use syn::spanned::Spanned;
-use syn::{Attribute, Fields, Meta, parse_str, visit::Visit};
+use syn::{Fields, parse_str, visit::Visit};
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 
 pub struct MissingSignerDetector {
@@ -31,21 +31,6 @@ impl MissingSignerDetector {
         if let syn::Type::Path(type_path) = &field.ty {
             if let Some(segment) = type_path.path.segments.last() {
                 return segment.ident == "Signer";
-            }
-        }
-        false
-    }
-
-    /// Check if a struct has the #[derive(Accounts)] attribute
-    fn has_accounts_derive(&self, attrs: &[Attribute]) -> bool {
-        for attr in attrs {
-            if let Meta::List(meta_list) = &attr.meta {
-                if meta_list.path.is_ident("derive") {
-                    let tokens = meta_list.tokens.to_string();
-                    if tokens.contains("Accounts") {
-                        return true;
-                    }
-                }
             }
         }
         false
@@ -88,7 +73,7 @@ impl Detector for MissingSignerDetector {
 impl<'ast> Visit<'ast> for MissingSignerDetector {
     fn visit_item_struct(&mut self, node: &'ast syn::ItemStruct) {
         // Check if this struct has #[derive(Accounts)]
-        if !self.has_accounts_derive(&node.attrs) {
+        if !AnchorPatterns::is_accounts_struct(node) {
             return;
         }
 

--- a/language-server/src/core/detectors/mod.rs
+++ b/language-server/src/core/detectors/mod.rs
@@ -2,8 +2,10 @@ pub mod detector;
 pub mod detector_config;
 pub mod manual_lamports_zeroing;
 pub mod missing_signer;
+pub mod sysvar_account_detector;
 pub mod unsafe_math;
 
 pub use manual_lamports_zeroing::*;
 pub use missing_signer::*;
+pub use sysvar_account_detector::*;
 pub use unsafe_math::*;

--- a/language-server/src/core/detectors/sysvar_account_detector.rs
+++ b/language-server/src/core/detectors/sysvar_account_detector.rs
@@ -34,6 +34,7 @@ impl SysvarAccountDetector {
                     // Extract the sysvar type from generic arguments
                     if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
                         // Look for the second generic argument (the sysvar type)
+                        // to provide a more accurate suggestion
                         if args.args.len() >= 2 {
                             if let Some(syn::GenericArgument::Type(Type::Path(type_path))) =
                                 args.args.iter().nth(1)

--- a/language-server/src/core/detectors/sysvar_account_detector.rs
+++ b/language-server/src/core/detectors/sysvar_account_detector.rs
@@ -1,0 +1,144 @@
+use super::detector::Detector;
+use super::detector_config::DetectorConfig;
+use crate::core::utilities::DiagnosticBuilder;
+use syn::spanned::Spanned;
+use syn::{Attribute, Fields, Meta, Type, TypePath, parse_str, visit::Visit};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
+
+pub struct SysvarAccountDetector {
+    diagnostics: Vec<Diagnostic>,
+    config: DetectorConfig,
+}
+
+impl SysvarAccountDetector {
+    pub fn new() -> Self {
+        Self {
+            diagnostics: Vec::new(),
+            config: DetectorConfig::default(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn with_config(config: DetectorConfig) -> Self {
+        Self {
+            diagnostics: Vec::new(),
+            config,
+        }
+    }
+
+    /// Check if a field is a Sysvar account type
+    fn is_sysvar_field(&self, field: &syn::Field) -> Option<String> {
+        if let Type::Path(TypePath { path, .. }) = &field.ty {
+            if let Some(segment) = path.segments.last() {
+                if segment.ident == "Sysvar" {
+                    // Extract the sysvar type from generic arguments
+                    if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                        // Look for the second generic argument (the sysvar type)
+                        if args.args.len() >= 2 {
+                            if let Some(syn::GenericArgument::Type(Type::Path(type_path))) =
+                                args.args.iter().nth(1)
+                            {
+                                if let Some(type_segment) = type_path.path.segments.last() {
+                                    let sysvar_type = type_segment.ident.to_string();
+                                    // All sysvars support get() through the Sysvar trait
+                                    return Some(sysvar_type);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Check if a struct has the #[derive(Accounts)] attribute
+    fn has_accounts_derive(&self, attrs: &[Attribute]) -> bool {
+        for attr in attrs {
+            if let Meta::List(meta_list) = &attr.meta {
+                if meta_list.path.is_ident("derive") {
+                    let tokens = meta_list.tokens.to_string();
+                    if tokens.contains("Accounts") {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    /// Generate suggestion message for the specific sysvar type
+    fn get_suggestion_message(&self, sysvar_type: &str) -> String {
+        format!(
+            "Consider using {}::get()? instead of Sysvar<'info, {}>. The get() method is more efficient as it doesn't require passing the sysvar account in the transaction.",
+            sysvar_type, sysvar_type
+        )
+    }
+}
+
+impl Detector for SysvarAccountDetector {
+    fn id(&self) -> &'static str {
+        "INEFFICIENT_SYSVAR_ACCOUNT"
+    }
+
+    fn name(&self) -> &'static str {
+        "Inefficient Sysvar Account Usage"
+    }
+
+    fn description(&self) -> &'static str {
+        "Detects usage of Sysvar<'info, Type> accounts and suggests using the more efficient get() method"
+    }
+
+    fn message(&self) -> &'static str {
+        "Sysvar account usage detected. Consider using the get() method for better efficiency."
+    }
+
+    fn default_severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::WARNING
+    }
+
+    fn analyze(&mut self, content: &str) -> Vec<Diagnostic> {
+        self.diagnostics.clear();
+
+        // Run default detection logic
+        if let Ok(syntax_tree) = parse_str::<syn::File>(content) {
+            self.visit_file(&syntax_tree);
+        }
+
+        self.diagnostics.clone()
+    }
+}
+
+impl<'ast> Visit<'ast> for SysvarAccountDetector {
+    fn visit_item_struct(&mut self, node: &'ast syn::ItemStruct) {
+        // Check if this struct has #[derive(Accounts)]
+        if !self.has_accounts_derive(&node.attrs) {
+            return;
+        }
+
+        // Check each field for Sysvar usage
+        if let Fields::Named(fields) = &node.fields {
+            for field in &fields.named {
+                if let Some(sysvar_type) = self.is_sysvar_field(field) {
+                    let severity = self
+                        .config
+                        .severity_override
+                        .unwrap_or(self.default_severity());
+
+                    let message = self.get_suggestion_message(&sysvar_type);
+
+                    self.diagnostics.push(DiagnosticBuilder::create(
+                        DiagnosticBuilder::create_range_from_span(field.span()),
+                        message,
+                        severity,
+                        self.id().to_string(),
+                        None,
+                    ));
+                }
+            }
+        }
+
+        // Continue visiting children
+        syn::visit::visit_item_struct(self, node);
+    }
+}

--- a/language-server/tests/sysvar_account_detector_test.rs
+++ b/language-server/tests/sysvar_account_detector_test.rs
@@ -1,0 +1,305 @@
+use language_server::core::detectors::{
+    detector::Detector, sysvar_account_detector::SysvarAccountDetector,
+};
+use tower_lsp::lsp_types::DiagnosticSeverity;
+
+#[test]
+fn test_detector_metadata() {
+    let detector = SysvarAccountDetector::new();
+
+    assert_eq!(detector.id(), "INEFFICIENT_SYSVAR_ACCOUNT");
+    assert_eq!(detector.name(), "Inefficient Sysvar Account Usage");
+    assert_eq!(
+        detector.description(),
+        "Detects usage of Sysvar<'info, Type> accounts and suggests using the more efficient get() method"
+    );
+    assert_eq!(detector.default_severity(), DiagnosticSeverity::WARNING);
+}
+
+#[test]
+fn test_detects_clock_sysvar_account() {
+    let mut detector = SysvarAccountDetector::new();
+
+    let code_with_clock_sysvar = r#"
+        use anchor_lang::prelude::*;
+
+        #[derive(Accounts)]
+        pub struct MyContext<'info> {
+            pub clock: Sysvar<'info, Clock>,
+            #[account(mut)]
+            pub user: Account<'info, User>,
+        }
+
+        #[account]
+        pub struct User {
+            pub timestamp: i64,
+        }
+    "#;
+
+    let diagnostics = detector.analyze(code_with_clock_sysvar);
+    assert_eq!(diagnostics.len(), 1);
+
+    let diagnostic = &diagnostics[0];
+    assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::WARNING));
+    assert!(diagnostic.message.contains("Clock::get()?"));
+    assert!(diagnostic.message.contains("more efficient"));
+}
+
+#[test]
+fn test_detects_epoch_schedule_sysvar_account() {
+    let mut detector = SysvarAccountDetector::new();
+
+    let code_with_epoch_schedule_sysvar = r#"
+        use anchor_lang::prelude::*;
+
+        #[derive(Accounts)]
+        pub struct MyContext<'info> {
+            pub epoch_schedule: Sysvar<'info, EpochSchedule>,
+            #[account(mut)]
+            pub user: Account<'info, User>,
+        }
+    "#;
+
+    let diagnostics = detector.analyze(code_with_epoch_schedule_sysvar);
+    assert_eq!(diagnostics.len(), 1);
+
+    let diagnostic = &diagnostics[0];
+    assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::WARNING));
+    assert!(diagnostic.message.contains("EpochSchedule::get()?"));
+}
+
+#[test]
+fn test_detects_rent_sysvar_account() {
+    let mut detector = SysvarAccountDetector::new();
+
+    let code_with_rent_sysvar = r#"
+        use anchor_lang::prelude::*;
+
+        #[derive(Accounts)]
+        pub struct MyContext<'info> {
+            pub rent: Sysvar<'info, Rent>,
+            #[account(mut)]
+            pub user: Account<'info, User>,
+        }
+    "#;
+
+    let diagnostics = detector.analyze(code_with_rent_sysvar);
+    assert_eq!(diagnostics.len(), 1);
+
+    let diagnostic = &diagnostics[0];
+    assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::WARNING));
+    assert!(diagnostic.message.contains("Rent::get()?"));
+}
+
+#[test]
+fn test_detects_slot_hashes_sysvar_account() {
+    let mut detector = SysvarAccountDetector::new();
+
+    let code_with_slot_hashes_sysvar = r#"
+        use anchor_lang::prelude::*;
+
+        #[derive(Accounts)]
+        pub struct MyContext<'info> {
+            pub slot_hashes: Sysvar<'info, SlotHashes>,
+            #[account(mut)]
+            pub user: Account<'info, User>,
+        }
+    "#;
+
+    let diagnostics = detector.analyze(code_with_slot_hashes_sysvar);
+    assert_eq!(diagnostics.len(), 1);
+
+    let diagnostic = &diagnostics[0];
+    assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::WARNING));
+    assert!(diagnostic.message.contains("SlotHashes::get()?"));
+}
+
+#[test]
+fn test_detects_multiple_sysvar_accounts() {
+    let mut detector = SysvarAccountDetector::new();
+
+    let code_with_multiple_sysvars = r#"
+        use anchor_lang::prelude::*;
+
+        #[derive(Accounts)]
+        pub struct MyContext<'info> {
+            pub clock: Sysvar<'info, Clock>,
+            pub rent: Sysvar<'info, Rent>,
+            pub epoch_schedule: Sysvar<'info, EpochSchedule>,
+            pub slot_hashes: Sysvar<'info, SlotHashes>,
+            pub stake_history: Sysvar<'info, StakeHistory>,
+            pub instructions: Sysvar<'info, Instructions>,
+            #[account(mut)]
+            pub user: Account<'info, User>,
+        }
+    "#;
+
+    let diagnostics = detector.analyze(code_with_multiple_sysvars);
+    assert_eq!(diagnostics.len(), 6);
+
+    // Check that all sysvars are detected (since all support get() via trait)
+    let messages: Vec<String> = diagnostics.iter().map(|d| d.message.clone()).collect();
+    assert!(messages.iter().any(|m| m.contains("Clock::get()?")));
+    assert!(messages.iter().any(|m| m.contains("Rent::get()?")));
+    assert!(messages.iter().any(|m| m.contains("EpochSchedule::get()?")));
+    assert!(messages.iter().any(|m| m.contains("SlotHashes::get()?")));
+    assert!(messages.iter().any(|m| m.contains("StakeHistory::get()?")));
+    assert!(messages.iter().any(|m| m.contains("Instructions::get()?")));
+}
+
+#[test]
+fn test_ignores_non_sysvar_accounts() {
+    let mut detector = SysvarAccountDetector::new();
+
+    let code_with_non_sysvar = r#"
+        use anchor_lang::prelude::*;
+
+        #[derive(Accounts)]
+        pub struct MyContext<'info> {
+            /// CHECK: Regular AccountInfo, not Sysvar<T>
+            pub instructions: AccountInfo<'info>,
+            #[account(mut)]
+            pub user: Account<'info, User>,
+        }
+    "#;
+
+    let diagnostics = detector.analyze(code_with_non_sysvar);
+    assert_eq!(diagnostics.len(), 0); // Should not detect non-Sysvar account types
+}
+
+#[test]
+fn test_ignores_non_accounts_structs() {
+    let mut detector = SysvarAccountDetector::new();
+
+    let code_with_mixed_structs = r#"
+        use anchor_lang::prelude::*;
+
+        // This should be ignored (no #[derive(Accounts)])
+        pub struct RegularStruct {
+            pub clock: Sysvar<'info, Clock>,
+        }
+
+        #[derive(Accounts)]
+        pub struct ValidAccounts<'info> {
+            pub clock: Sysvar<'info, Clock>,
+        }
+
+        // This should also be ignored
+        #[account]
+        pub struct DataStruct {
+            pub timestamp: i64,
+        }
+    "#;
+
+    let diagnostics = detector.analyze(code_with_mixed_structs);
+    assert_eq!(diagnostics.len(), 1); // Only the Accounts struct should be flagged
+}
+
+#[test]
+fn test_ignores_regular_accounts() {
+    let mut detector = SysvarAccountDetector::new();
+
+    let code_with_regular_accounts = r#"
+        use anchor_lang::prelude::*;
+
+        #[derive(Accounts)]
+        pub struct MyContext<'info> {
+            #[account(mut)]
+            pub user: Account<'info, User>,
+            pub authority: Signer<'info>,
+            pub system_program: Program<'info, System>,
+        }
+
+        #[account]
+        pub struct User {
+            pub balance: u64,
+        }
+    "#;
+
+    let diagnostics = detector.analyze(code_with_regular_accounts);
+    assert_eq!(diagnostics.len(), 0); // No sysvars to detect
+}
+
+#[test]
+fn test_real_world_anchor_pattern() {
+    let mut detector = SysvarAccountDetector::new();
+
+    let real_world_code = r#"
+        use anchor_lang::prelude::*;
+
+        #[program]
+        pub mod my_program {
+            use super::*;
+
+            pub fn initialize_with_timestamp(ctx: Context<InitializeWithTimestamp>) -> Result<()> {
+                let current_time = ctx.accounts.clock.unix_timestamp;
+                ctx.accounts.user_account.created_at = current_time;
+                Ok(())
+            }
+        }
+
+        #[derive(Accounts)]
+        pub struct InitializeWithTimestamp<'info> {
+            #[account(init, payer = authority, space = 8 + 32)]
+            pub user_account: Account<'info, UserAccount>,
+            #[account(mut)]
+            pub authority: Signer<'info>,
+            pub clock: Sysvar<'info, Clock>,
+            pub system_program: Program<'info, System>,
+        }
+
+        #[account]
+        pub struct UserAccount {
+            pub authority: Pubkey,
+            pub created_at: i64,
+        }
+    "#;
+
+    let diagnostics = detector.analyze(real_world_code);
+    assert_eq!(diagnostics.len(), 1);
+
+    let diagnostic = &diagnostics[0];
+    assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::WARNING));
+    assert!(diagnostic.message.contains("Clock::get()?"));
+    assert!(diagnostic.message.contains("more efficient"));
+}
+
+#[test]
+fn test_invalid_syntax_handling() {
+    let mut detector = SysvarAccountDetector::new();
+
+    let invalid_code = r#"
+        use anchor_lang::prelude::*;
+
+        #[derive(Accounts)]
+        pub struct BrokenStruct<'info> {
+            pub clock: Sysvar<'info,
+        }
+    "#;
+
+    // Should handle invalid syntax gracefully
+    let diagnostics = detector.analyze(invalid_code);
+    assert_eq!(diagnostics.len(), 0);
+}
+
+#[test]
+fn test_detector_state_isolation() {
+    let mut detector1 = SysvarAccountDetector::new();
+    let mut detector2 = SysvarAccountDetector::new();
+
+    let code = r#"
+        use anchor_lang::prelude::*;
+
+        #[derive(Accounts)]
+        pub struct TestAccounts<'info> {
+            pub clock: Sysvar<'info, Clock>,
+        }
+    "#;
+
+    let diagnostics1 = detector1.analyze(code);
+    let diagnostics2 = detector2.analyze(code);
+
+    // Each detector instance should produce the same results
+    assert_eq!(diagnostics1.len(), diagnostics2.len());
+    assert_eq!(diagnostics1.len(), 1);
+}


### PR DESCRIPTION
## Description

This PR adds `SysvarAccountDetector` that detects when the `Sysvar<'info, T>` account was used

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #
