### PR TITLE
Add instruction context detectors

### DIFF
--- a/extension/src/coverage/tests/coverageDecoration.test.ts
+++ b/extension/src/coverage/tests/coverageDecoration.test.ts
@@ -487,21 +487,9 @@ suite("Coverage Decoration Test Suite", () => {
         is_gap_region: false,
       };
 
-      // Test gap region
-      const gapSegment: CoverageSegment = {
-        line: 15,
-        column: 5,
-        execution_count: 0,
-        has_count: true,
-        is_region_entry: false,
-        is_gap_region: true,
-      };
-
       const noCountResult = coverageDecorations.testShouldDisplaySegment(noCountSegment, mockEditor);
-      const gapResult = coverageDecorations.testShouldDisplaySegment(gapSegment, mockEditor);
 
       assert.strictEqual(noCountResult, false, "Should filter out segments without has_count");
-      assert.strictEqual(gapResult, false, "Should filter out gap regions");
     });
   });
 });

--- a/language-server/src/backend.rs
+++ b/language-server/src/backend.rs
@@ -1,10 +1,9 @@
 use crate::core::{
     DetectorInfo, DetectorRegistry, DetectorRegistryBuilder, FileScanner,
     ImmutableAccountMutatedDetector, InstructionAttributeInvalidDetector,
-    InstructionAttributeUnusedDetector, ManualLamportsZeroingDetector, MissingInitspaceDetector,
-    MissingSignerDetector,
-    ScanCompleteNotification, ScanResult, ScanSummary, SysvarAccountDetector, UnsafeMathDetector,
-    MissingCheckCommentDetector,
+    InstructionAttributeUnusedDetector, ManualLamportsZeroingDetector, MissingCheckCommentDetector,
+    MissingInitspaceDetector, MissingSignerDetector, ScanCompleteNotification, ScanResult,
+    ScanSummary, SysvarAccountDetector, UnsafeMathDetector,
 };
 use log::info;
 use std::sync::Arc;

--- a/language-server/src/backend.rs
+++ b/language-server/src/backend.rs
@@ -1,8 +1,10 @@
 use crate::core::{
     DetectorInfo, DetectorRegistry, DetectorRegistryBuilder, FileScanner,
-    ImmutableAccountMutatedDetector, ManualLamportsZeroingDetector, MissingInitspaceDetector,
-    MissingSignerDetector, ScanCompleteNotification, ScanResult, ScanSummary,
-    SysvarAccountDetector, UnsafeMathDetector,
+    ImmutableAccountMutatedDetector, InstructionAttributeInvalidDetector,
+    InstructionAttributeUnusedDetector, ManualLamportsZeroingDetector, MissingInitspaceDetector,
+    MissingSignerDetector,
+    ScanCompleteNotification, ScanResult, ScanSummary, SysvarAccountDetector, UnsafeMathDetector,
+    MissingCheckCommentDetector,
 };
 use log::info;
 use std::sync::Arc;
@@ -309,5 +311,8 @@ fn create_default_registry() -> DetectorRegistry {
         .with_detector(SysvarAccountDetector::default())
         .with_detector(ImmutableAccountMutatedDetector::default())
         .with_detector(MissingInitspaceDetector::default())
+        .with_detector(InstructionAttributeUnusedDetector::default())
+        .with_detector(InstructionAttributeInvalidDetector::default())
+        .with_detector(MissingCheckCommentDetector::default())
         .build()
 }

--- a/language-server/src/core/detectors/instruction_attribute_invalid.rs
+++ b/language-server/src/core/detectors/instruction_attribute_invalid.rs
@@ -1,0 +1,278 @@
+use super::detector::Detector;
+use super::detector_config::DetectorConfig;
+use crate::core::utilities::{DiagnosticBuilder, anchor_patterns::AnchorPatterns};
+use std::path::PathBuf;
+use syn::{parse_str, visit::Visit, Meta, ItemFn, FnArg, PatType, Type, TypePath};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
+use std::collections::HashMap;
+
+#[derive(Default)]
+pub struct InstructionAttributeInvalidDetector {
+    diagnostics: Vec<Diagnostic>,
+    config: DetectorConfig,
+    // Map from function name to its parameters (excluding Context)
+    instruction_handlers: HashMap<String, Vec<(String, String)>>, // (param_name, param_type)
+}
+
+impl InstructionAttributeInvalidDetector {
+    #[allow(dead_code)]
+    pub fn with_config(config: DetectorConfig) -> Self {
+        Self {
+            diagnostics: Vec::new(),
+            config,
+            instruction_handlers: HashMap::new(),
+        }
+    }
+
+    /// Extract parameters from an instruction handler function and return (context_struct_name, parameters)
+    fn extract_handler_parameters(&self, item_fn: &ItemFn) -> Option<(String, Vec<(String, String)>)> {
+        let mut parameters = Vec::new();
+        let mut context_struct_name: Option<String> = None;
+        
+        for input in &item_fn.sig.inputs {
+            if let FnArg::Typed(PatType { pat, ty, .. }) = input {
+                if let syn::Pat::Ident(pat_ident) = &**pat {
+                    let param_name = pat_ident.ident.to_string();
+                    
+                    // Check if this is a Context parameter
+                    if let Type::Path(TypePath { path, .. }) = &**ty {
+                        if let Some(segment) = path.segments.first() {
+                            if segment.ident == "Context" {
+                                // Extract the context struct name from Context<StructName>
+                                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                                    if let Some(syn::GenericArgument::Type(Type::Path(context_type))) = args.args.first() {
+                                        if let Some(context_segment) = context_type.path.segments.first() {
+                                            context_struct_name = Some(context_segment.ident.to_string());
+                                        }
+                                    }
+                                }
+                                continue; // Skip the Context parameter itself
+                            }
+                        }
+                    }
+                    
+                    // Extract type as string with better formatting
+                    let type_str = self.extract_type_string(ty);
+                    parameters.push((param_name, type_str));
+                }
+            }
+        }
+        
+        // Only return if we found a context struct name
+        context_struct_name.map(|struct_name| (struct_name, parameters))
+    }
+
+    /// Extract a clean type string from a syn::Type
+    fn extract_type_string(&self, ty: &Type) -> String {
+        match ty {
+            Type::Path(type_path) => {
+                let mut result = String::new();
+                for (i, segment) in type_path.path.segments.iter().enumerate() {
+                    if i > 0 {
+                        result.push_str("::");
+                    }
+                    result.push_str(&segment.ident.to_string());
+                    
+                    // Handle generic arguments
+                    if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                        result.push('<');
+                        for (j, arg) in args.args.iter().enumerate() {
+                            if j > 0 {
+                                result.push_str(", ");
+                            }
+                            match arg {
+                                syn::GenericArgument::Type(inner_ty) => {
+                                    result.push_str(&self.extract_type_string(inner_ty));
+                                }
+                                syn::GenericArgument::Lifetime(lifetime) => {
+                                    result.push_str(&format!("'{}", lifetime.ident));
+                                }
+                                _ => {
+                                    result.push_str(&format!("{:?}", arg));
+                                }
+                            }
+                        }
+                        result.push('>');
+                    }
+                }
+                result
+            }
+            Type::Reference(type_ref) => {
+                let mut result = String::from("&");
+                if let Some(lifetime) = &type_ref.lifetime {
+                    result.push_str(&format!("'{} ", lifetime.ident));
+                }
+                if type_ref.mutability.is_some() {
+                    result.push_str("mut ");
+                }
+                result.push_str(&self.extract_type_string(&type_ref.elem));
+                result
+            }
+            Type::Slice(type_slice) => {
+                format!("[{}]", self.extract_type_string(&type_slice.elem))
+            }
+            Type::Array(type_array) => {
+                format!("[{}; {:?}]", self.extract_type_string(&type_array.elem), type_array.len)
+            }
+            Type::Tuple(type_tuple) => {
+                let mut result = String::from("(");
+                for (i, elem) in type_tuple.elems.iter().enumerate() {
+                    if i > 0 {
+                        result.push_str(", ");
+                    }
+                    result.push_str(&self.extract_type_string(elem));
+                }
+                result.push(')');
+                result
+            }
+            _ => {
+                // Fallback to debug format
+                format!("{:?}", ty)
+            }
+        }
+    }
+
+    /// Check if instruction attribute parameters match the handler parameters
+    fn validate_instruction_parameters(&self, struct_name: &str, instruction_params: &[(String, String, proc_macro2::Span)]) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+        
+        // Find the corresponding handler function using the exact struct name
+        if let Some(handler_params) = self.instruction_handlers.get(struct_name) {
+            
+            // Check if instruction parameters are in the correct order and not skipping any
+            for (i, (param_name, param_type, param_span)) in instruction_params.iter().enumerate() {
+                if i >= handler_params.len() {
+                    // Too many parameters in instruction attribute
+                    let severity = self.config.severity_override.unwrap_or(self.default_severity());
+                    let message = format!("Instruction parameter '{}' not found in handler function", param_name);
+                    
+                    diagnostics.push(DiagnosticBuilder::create(
+                        DiagnosticBuilder::create_range_from_span(*param_span),
+                        message,
+                        severity,
+                        self.id().to_string(),
+                        None,
+                    ));
+                } else {
+                    let (expected_name, expected_type) = &handler_params[i];
+                    
+                    // Check if parameter name matches
+                    if param_name != expected_name {
+                        let severity = self.config.severity_override.unwrap_or(self.default_severity());
+                        let message = format!(
+                            "Instruction parameter '{}' does not match handler parameter '{}' at position {}. Parameters must be in the same order as the handler function.",
+                            param_name, expected_name, i + 1
+                        );
+                        
+                        diagnostics.push(DiagnosticBuilder::create(
+                            DiagnosticBuilder::create_range_from_span(*param_span),
+                            message,
+                            severity,
+                            self.id().to_string(),
+                            None,
+                        ));
+                    } else {
+                        // Check if parameter type matches
+                        let normalized_instruction_type = self.normalize_type(param_type);
+                        let normalized_handler_type = self.normalize_type(expected_type);
+                        
+                        if normalized_instruction_type != normalized_handler_type {
+                            let severity = self.config.severity_override.unwrap_or(self.default_severity());
+                            let message = format!(
+                                "Instruction parameter '{}' has type '{}' but handler function expects type '{}'",
+                                param_name, param_type, expected_type
+                            );
+                            
+                            diagnostics.push(DiagnosticBuilder::create(
+                                DiagnosticBuilder::create_range_from_span(*param_span),
+                                message,
+                                severity,
+                                self.id().to_string(),
+                                None,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        
+        diagnostics
+    }
+
+    /// Normalize type strings for comparison
+    fn normalize_type(&self, type_str: &str) -> String {
+        type_str
+            .replace(" ", "")
+            .replace("&str", "String") // Common alias
+            .replace("&'static str", "String")
+            .replace("&'_str", "String")
+            .to_lowercase()
+    }
+}
+
+impl Detector for InstructionAttributeInvalidDetector {
+    fn id(&self) -> &'static str {
+        "INSTRUCTION_ATTRIBUTE_INVALID"
+    }
+
+    fn name(&self) -> &'static str {
+        "Instruction Attribute Invalid"
+    }
+
+    fn description(&self) -> &'static str {
+        "Detects invalid use of instruction attribute - parameters must be in the same order as the handler function and cannot skip parameters"
+    }
+
+    fn message(&self) -> &'static str {
+        "Invalid use of instruction attribute"
+    }
+
+    fn default_severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::ERROR
+    }
+
+    fn analyze(&mut self, content: &str, _file_path: Option<&PathBuf>) -> Vec<Diagnostic> {
+        self.diagnostics.clear();
+        self.instruction_handlers.clear();
+
+        // Run default detection logic
+        if let Ok(syntax_tree) = parse_str::<syn::File>(content) {
+            // Collect all instruction handler functions (any function with Context<T> parameter)
+            self.visit_file(&syntax_tree);
+        }
+
+        self.diagnostics.clone()
+    }
+}
+
+impl<'ast> Visit<'ast> for InstructionAttributeInvalidDetector {
+    fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+        // Collect any function that has a Context<T> parameter (potential instruction handler)
+        if let Some((context_struct_name, params)) = self.extract_handler_parameters(node) {
+            self.instruction_handlers.insert(context_struct_name, params);
+        }
+        
+        // Continue visiting children
+        syn::visit::visit_item_fn(self, node);
+    }
+
+    fn visit_item_struct(&mut self, node: &'ast syn::ItemStruct) {
+        // Only check structs with #[derive(Accounts)]
+        if !AnchorPatterns::is_accounts_struct(node) {
+            return;
+        }
+
+        // Extract instruction parameters
+        let instruction_params = AnchorPatterns::extract_instruction_parameters(node);
+        
+        // Only validate if there are instruction parameters
+        if !instruction_params.is_empty() {
+            let struct_name = node.ident.to_string();
+            let validation_diagnostics = self.validate_instruction_parameters(&struct_name, &instruction_params);
+            self.diagnostics.extend(validation_diagnostics);
+        }
+
+        // Continue visiting children
+        syn::visit::visit_item_struct(self, node);
+    }
+}

--- a/language-server/src/core/detectors/instruction_attribute_unused.rs
+++ b/language-server/src/core/detectors/instruction_attribute_unused.rs
@@ -2,7 +2,7 @@ use super::detector::Detector;
 use super::detector_config::DetectorConfig;
 use crate::core::utilities::{DiagnosticBuilder, anchor_patterns::AnchorPatterns};
 use std::path::PathBuf;
-use syn::{parse_str, visit::Visit, Fields, Meta};
+use syn::{Fields, Meta, parse_str, visit::Visit};
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 
 #[derive(Default)]
@@ -21,14 +21,18 @@ impl InstructionAttributeUnusedDetector {
     }
 
     /// Check if a parameter is used in account constraints
-    fn is_parameter_used_in_constraints(&self, param_name: &str, fields: &syn::FieldsNamed) -> bool {
+    fn is_parameter_used_in_constraints(
+        &self,
+        param_name: &str,
+        fields: &syn::FieldsNamed,
+    ) -> bool {
         for field in &fields.named {
             // Check account constraints in field attributes
             for attr in &field.attrs {
                 if attr.path().is_ident("account") {
                     if let Meta::List(meta_list) = &attr.meta {
                         let constraint_tokens = meta_list.tokens.to_string();
-                        
+
                         // Check if parameter is referenced in constraints
                         if constraint_tokens.contains(param_name) {
                             return true;
@@ -91,9 +95,9 @@ impl<'ast> Visit<'ast> for InstructionAttributeUnusedDetector {
 
         // Extract instruction parameters
         let instruction_params = AnchorPatterns::extract_instruction_parameters(node);
-        
+
         // Check each parameter for usage
-        for (param_name, _ ,param_span) in instruction_params {
+        for (param_name, _, param_span) in instruction_params {
             if !self.is_parameter_used(&param_name, node) {
                 let severity = self
                     .config

--- a/language-server/src/core/detectors/instruction_attribute_unused.rs
+++ b/language-server/src/core/detectors/instruction_attribute_unused.rs
@@ -1,0 +1,118 @@
+use super::detector::Detector;
+use super::detector_config::DetectorConfig;
+use crate::core::utilities::{DiagnosticBuilder, anchor_patterns::AnchorPatterns};
+use std::path::PathBuf;
+use syn::{parse_str, visit::Visit, Fields, Meta};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
+
+#[derive(Default)]
+pub struct InstructionAttributeUnusedDetector {
+    diagnostics: Vec<Diagnostic>,
+    config: DetectorConfig,
+}
+
+impl InstructionAttributeUnusedDetector {
+    #[allow(dead_code)]
+    pub fn with_config(config: DetectorConfig) -> Self {
+        Self {
+            diagnostics: Vec::new(),
+            config,
+        }
+    }
+
+    /// Check if a parameter is used in account constraints
+    fn is_parameter_used_in_constraints(&self, param_name: &str, fields: &syn::FieldsNamed) -> bool {
+        for field in &fields.named {
+            // Check account constraints in field attributes
+            for attr in &field.attrs {
+                if attr.path().is_ident("account") {
+                    if let Meta::List(meta_list) = &attr.meta {
+                        let constraint_tokens = meta_list.tokens.to_string();
+                        
+                        // Check if parameter is referenced in constraints
+                        if constraint_tokens.contains(param_name) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    /// Check if parameter is used anywhere in the struct
+    fn is_parameter_used(&self, param_name: &str, item_struct: &syn::ItemStruct) -> bool {
+        if let Fields::Named(fields) = &item_struct.fields {
+            return self.is_parameter_used_in_constraints(param_name, fields);
+        }
+        false
+    }
+}
+
+impl Detector for InstructionAttributeUnusedDetector {
+    fn id(&self) -> &'static str {
+        "INSTRUCTION_ATTRIBUTE_UNUSED"
+    }
+
+    fn name(&self) -> &'static str {
+        "Instruction Attribute Unused"
+    }
+
+    fn description(&self) -> &'static str {
+        "Detects unused instruction parameters in the #[instruction(...)] attribute"
+    }
+
+    fn message(&self) -> &'static str {
+        "Unused instruction parameter"
+    }
+
+    fn default_severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::WARNING
+    }
+
+    fn analyze(&mut self, content: &str, _file_path: Option<&PathBuf>) -> Vec<Diagnostic> {
+        self.diagnostics.clear();
+
+        // Run default detection logic
+        if let Ok(syntax_tree) = parse_str::<syn::File>(content) {
+            self.visit_file(&syntax_tree);
+        }
+
+        self.diagnostics.clone()
+    }
+}
+
+impl<'ast> Visit<'ast> for InstructionAttributeUnusedDetector {
+    fn visit_item_struct(&mut self, node: &'ast syn::ItemStruct) {
+        // Only check structs with #[derive(Accounts)]
+        if !AnchorPatterns::is_accounts_struct(node) {
+            return;
+        }
+
+        // Extract instruction parameters
+        let instruction_params = AnchorPatterns::extract_instruction_parameters(node);
+        
+        // Check each parameter for usage
+        for (param_name, _ ,param_span) in instruction_params {
+            if !self.is_parameter_used(&param_name, node) {
+                let severity = self
+                    .config
+                    .severity_override
+                    .unwrap_or(self.default_severity());
+
+                let message = format!("{}: '{}'", self.message(), param_name);
+
+                self.diagnostics.push(DiagnosticBuilder::create(
+                    DiagnosticBuilder::create_range_from_span(param_span),
+                    message,
+                    severity,
+                    self.id().to_string(),
+                    None,
+                ));
+            }
+        }
+
+        // Continue visiting children
+        syn::visit::visit_item_struct(self, node);
+    }
+}

--- a/language-server/src/core/detectors/missing_check_comment.rs
+++ b/language-server/src/core/detectors/missing_check_comment.rs
@@ -21,19 +21,6 @@ impl MissingCheckCommentDetector {
         }
     }
 
-    /// Check if a field type is AccountInfo or UncheckedAccount
-    fn is_unchecked_account_type(&self, field: &syn::Field) -> Option<String> {
-        if let Type::Path(TypePath { path, .. }) = &field.ty {
-            if let Some(segment) = path.segments.last() {
-                let type_name = segment.ident.to_string();
-                if type_name == "AccountInfo" || type_name == "UncheckedAccount" {
-                    return Some(type_name);
-                }
-            }
-        }
-        None
-    }
-
     /// Check if field has a /// CHECK: doc comment
     fn has_check_doc_comment(&self, field: &syn::Field) -> bool {
         for attr in &field.attrs {
@@ -106,7 +93,7 @@ impl<'ast> Visit<'ast> for MissingCheckCommentDetector {
         // Check each field for unchecked account types
         if let Fields::Named(fields) = &node.fields {
             for field in &fields.named {
-                if let Some(account_type) = self.is_unchecked_account_type(field) {
+                if let Some(account_type) = AnchorPatterns::is_unchecked_account_type(field) {
                     if !self.has_check_doc_comment(field) {
                         let field_name = field
                             .ident

--- a/language-server/src/core/detectors/missing_check_comment.rs
+++ b/language-server/src/core/detectors/missing_check_comment.rs
@@ -3,7 +3,7 @@ use super::detector_config::DetectorConfig;
 use crate::core::utilities::{DiagnosticBuilder, anchor_patterns::AnchorPatterns};
 use std::path::PathBuf;
 use syn::spanned::Spanned;
-use syn::{parse_str, visit::Visit, Fields, Type, TypePath};
+use syn::{Fields, Type, TypePath, parse_str, visit::Visit};
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 
 #[derive(Default)]
@@ -136,4 +136,4 @@ impl<'ast> Visit<'ast> for MissingCheckCommentDetector {
         // Continue visiting children
         syn::visit::visit_item_struct(self, node);
     }
-} 
+}

--- a/language-server/src/core/detectors/missing_check_comment.rs
+++ b/language-server/src/core/detectors/missing_check_comment.rs
@@ -1,0 +1,139 @@
+use super::detector::Detector;
+use super::detector_config::DetectorConfig;
+use crate::core::utilities::{DiagnosticBuilder, anchor_patterns::AnchorPatterns};
+use std::path::PathBuf;
+use syn::spanned::Spanned;
+use syn::{parse_str, visit::Visit, Fields, Type, TypePath};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
+
+#[derive(Default)]
+pub struct MissingCheckCommentDetector {
+    diagnostics: Vec<Diagnostic>,
+    config: DetectorConfig,
+}
+
+impl MissingCheckCommentDetector {
+    #[allow(dead_code)]
+    pub fn with_config(config: DetectorConfig) -> Self {
+        Self {
+            diagnostics: Vec::new(),
+            config,
+        }
+    }
+
+    /// Check if a field type is AccountInfo or UncheckedAccount
+    fn is_unchecked_account_type(&self, field: &syn::Field) -> Option<String> {
+        if let Type::Path(TypePath { path, .. }) = &field.ty {
+            if let Some(segment) = path.segments.last() {
+                let type_name = segment.ident.to_string();
+                if type_name == "AccountInfo" || type_name == "UncheckedAccount" {
+                    return Some(type_name);
+                }
+            }
+        }
+        None
+    }
+
+    /// Check if field has a /// CHECK: doc comment
+    fn has_check_doc_comment(&self, field: &syn::Field) -> bool {
+        for attr in &field.attrs {
+            if attr.path().is_ident("doc") {
+                if let syn::Meta::NameValue(meta_name_value) = &attr.meta {
+                    if let syn::Expr::Lit(expr_lit) = &meta_name_value.value {
+                        if let syn::Lit::Str(lit_str) = &expr_lit.lit {
+                            let doc_content = lit_str.value();
+                            let trimmed_content = doc_content.trim();
+                            if trimmed_content.starts_with("CHECK:") {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    /// Generate a helpful suggestion message with example
+    fn get_suggestion_message(&self, field_name: &str, account_type: &str) -> String {
+        format!(
+            "Missing /// CHECK: doc comment for {} field '{}'. Add a doc comment explaining why this account doesn't need validation. Example:\n/// CHECK: This account is used for [explain purpose and why it's safe]",
+            account_type, field_name
+        )
+    }
+}
+
+impl Detector for MissingCheckCommentDetector {
+    fn id(&self) -> &'static str {
+        "MISSING_CHECK_COMMENT"
+    }
+
+    fn name(&self) -> &'static str {
+        "Missing CHECK Comment"
+    }
+
+    fn description(&self) -> &'static str {
+        "Detects AccountInfo and UncheckedAccount fields without required /// CHECK: doc comments"
+    }
+
+    fn message(&self) -> &'static str {
+        "Missing /// CHECK: doc comment for unchecked account"
+    }
+
+    fn default_severity(&self) -> DiagnosticSeverity {
+        DiagnosticSeverity::ERROR
+    }
+
+    fn analyze(&mut self, content: &str, _file_path: Option<&PathBuf>) -> Vec<Diagnostic> {
+        self.diagnostics.clear();
+
+        // Run default detection logic
+        if let Ok(syntax_tree) = parse_str::<syn::File>(content) {
+            self.visit_file(&syntax_tree);
+        }
+
+        self.diagnostics.clone()
+    }
+}
+
+impl<'ast> Visit<'ast> for MissingCheckCommentDetector {
+    fn visit_item_struct(&mut self, node: &'ast syn::ItemStruct) {
+        // Only check structs with #[derive(Accounts)]
+        if !AnchorPatterns::is_accounts_struct(node) {
+            return;
+        }
+
+        // Check each field for unchecked account types
+        if let Fields::Named(fields) = &node.fields {
+            for field in &fields.named {
+                if let Some(account_type) = self.is_unchecked_account_type(field) {
+                    if !self.has_check_doc_comment(field) {
+                        let field_name = field
+                            .ident
+                            .as_ref()
+                            .map(|ident| ident.to_string())
+                            .unwrap_or_else(|| "unknown".to_string());
+
+                        let severity = self
+                            .config
+                            .severity_override
+                            .unwrap_or(self.default_severity());
+
+                        let message = self.get_suggestion_message(&field_name, &account_type);
+
+                        self.diagnostics.push(DiagnosticBuilder::create(
+                            DiagnosticBuilder::create_range_from_span(field.span()),
+                            message,
+                            severity,
+                            self.id().to_string(),
+                            None,
+                        ));
+                    }
+                }
+            }
+        }
+
+        // Continue visiting children
+        syn::visit::visit_item_struct(self, node);
+    }
+} 

--- a/language-server/src/core/detectors/mod.rs
+++ b/language-server/src/core/detectors/mod.rs
@@ -1,14 +1,20 @@
 pub mod detector;
 pub mod detector_config;
 pub mod immutable_account_mutated_detector;
+pub mod instruction_attribute_unused;
+pub mod instruction_attribute_invalid;
 pub mod manual_lamports_zeroing;
+pub mod missing_check_comment;
 pub mod missing_initspace_detector;
 pub mod missing_signer;
 pub mod sysvar_account_detector;
 pub mod unsafe_math;
 
 pub use immutable_account_mutated_detector::*;
+pub use instruction_attribute_unused::*;
+pub use instruction_attribute_invalid::*;
 pub use manual_lamports_zeroing::*;
+pub use missing_check_comment::*;
 pub use missing_initspace_detector::*;
 pub use missing_signer::*;
 pub use sysvar_account_detector::*;

--- a/language-server/src/core/detectors/mod.rs
+++ b/language-server/src/core/detectors/mod.rs
@@ -1,8 +1,8 @@
 pub mod detector;
 pub mod detector_config;
 pub mod immutable_account_mutated_detector;
-pub mod instruction_attribute_unused;
 pub mod instruction_attribute_invalid;
+pub mod instruction_attribute_unused;
 pub mod manual_lamports_zeroing;
 pub mod missing_check_comment;
 pub mod missing_initspace_detector;
@@ -11,8 +11,8 @@ pub mod sysvar_account_detector;
 pub mod unsafe_math;
 
 pub use immutable_account_mutated_detector::*;
-pub use instruction_attribute_unused::*;
 pub use instruction_attribute_invalid::*;
+pub use instruction_attribute_unused::*;
 pub use manual_lamports_zeroing::*;
 pub use missing_check_comment::*;
 pub use missing_initspace_detector::*;

--- a/language-server/src/core/utilities/anchor_patterns.rs
+++ b/language-server/src/core/utilities/anchor_patterns.rs
@@ -167,4 +167,17 @@ impl AnchorPatterns {
 
         parameters
     }
+
+    /// Check if a field type is AccountInfo or UncheckedAccount
+    pub fn is_unchecked_account_type(field: &syn::Field) -> Option<String> {
+        if let syn::Type::Path(syn::TypePath { path, .. }) = &field.ty {
+            if let Some(segment) = path.segments.last() {
+                let type_name = segment.ident.to_string();
+                if type_name == "AccountInfo" || type_name == "UncheckedAccount" {
+                    return Some(type_name);
+                }
+            }
+        }
+        None
+    }
 }

--- a/language-server/src/core/utilities/anchor_patterns.rs
+++ b/language-server/src/core/utilities/anchor_patterns.rs
@@ -77,14 +77,16 @@ impl AnchorPatterns {
     }
 
     /// Extract parameter names and types from the #[instruction(...)] attribute
-    /// 
+    ///
     /// Returns a vector of tuples, where each tuple contains:
     /// - The parameter name
     /// - The parameter type
     /// - The span of the parameter
-    pub fn extract_instruction_parameters(item_struct: &syn::ItemStruct) -> Vec<(String, String, proc_macro2::Span)> {
+    pub fn extract_instruction_parameters(
+        item_struct: &syn::ItemStruct,
+    ) -> Vec<(String, String, proc_macro2::Span)> {
         let mut parameters = Vec::new();
-        
+
         for attr in &item_struct.attrs {
             if attr.path().is_ident("instruction") {
                 if let syn::Meta::List(meta_list) = &attr.meta {
@@ -95,7 +97,7 @@ impl AnchorPatterns {
                     let mut current_type = String::new();
                     let mut param_start_span: Option<proc_macro2::Span> = None;
                     let mut parsing_type = false;
-                    
+
                     while let Some(token) = token_iter.next() {
                         match token {
                             proc_macro2::TokenTree::Ident(ident) => {
@@ -109,12 +111,19 @@ impl AnchorPatterns {
                                 }
                             }
                             proc_macro2::TokenTree::Punct(punct) => {
-                                if punct.as_char() == ':' && !current_param.is_empty() && !parsing_type {
+                                if punct.as_char() == ':'
+                                    && !current_param.is_empty()
+                                    && !parsing_type
+                                {
                                     parsing_type = true;
                                 } else if punct.as_char() == ',' && parsing_type {
                                     // End of this parameter
                                     if let Some(span) = param_start_span {
-                                        parameters.push((current_param.clone(), current_type.trim().to_string(), span));
+                                        parameters.push((
+                                            current_param.clone(),
+                                            current_type.trim().to_string(),
+                                            span,
+                                        ));
                                     }
                                     current_param.clear();
                                     current_type.clear();
@@ -134,7 +143,8 @@ impl AnchorPatterns {
                                         proc_macro2::Delimiter::Bracket => ('[', ']'),
                                         proc_macro2::Delimiter::None => (' ', ' '),
                                     };
-                                    current_type.push_str(&format!("{}{}{}", 
+                                    current_type.push_str(&format!(
+                                        "{}{}{}",
                                         open_char,
                                         group.stream().to_string(),
                                         close_char
@@ -144,7 +154,7 @@ impl AnchorPatterns {
                             _ => {}
                         }
                     }
-                    
+
                     // Handle the last parameter if we ended without a comma
                     if !current_param.is_empty() && parsing_type {
                         if let Some(span) = param_start_span {
@@ -154,7 +164,7 @@ impl AnchorPatterns {
                 }
             }
         }
-        
+
         parameters
     }
 }

--- a/language-server/tests/instruction_attribute_invalid_test.rs
+++ b/language-server/tests/instruction_attribute_invalid_test.rs
@@ -1,0 +1,376 @@
+#[cfg(test)]
+mod tests {
+    use language_server::core::detectors::instruction_attribute_invalid::InstructionAttributeInvalidDetector;
+    use language_server::core::detectors::detector::Detector;
+    use tower_lsp::lsp_types::DiagnosticSeverity;
+
+    #[test]
+    fn test_valid_instruction_attribute_same_order() {
+        let mut detector = InstructionAttributeInvalidDetector::default();
+        
+        let code = r#"
+#[program]
+pub mod example {
+    use super::*;
+    
+    pub fn initialize(ctx: Context<Initialize>, input_one: String, input_two: String) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(input_one: String, input_two: String)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should be no diagnostics for valid usage
+        assert_eq!(diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_valid_instruction_attribute_partial_params() {
+        let mut detector = InstructionAttributeInvalidDetector::default();
+        
+        let code = r#"
+#[program]
+pub mod example {
+    use super::*;
+    
+    pub fn initialize(ctx: Context<Initialize>, input_one: String, input_two: String) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(input_one: String)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should be no diagnostics for valid partial usage
+        assert_eq!(diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_invalid_instruction_attribute_wrong_order() {
+        let mut detector = InstructionAttributeInvalidDetector::default();
+        
+        let code = r#"
+#[program]
+pub mod example {
+    use super::*;
+    
+    pub fn initialize(ctx: Context<Initialize>, input_one: String, input_two: String) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(input_two: String)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should report error for wrong parameter order
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
+        assert!(diagnostics[0].message.contains("input_two"));
+        assert!(diagnostics[0].message.contains("input_one"));
+        assert!(diagnostics[0].message.contains("same order"));
+    }
+
+    #[test]
+    fn test_invalid_instruction_attribute_too_many_params() {
+        let mut detector = InstructionAttributeInvalidDetector::default();
+        
+        let code = r#"
+#[program]
+pub mod example {
+    use super::*;
+    
+    pub fn initialize(ctx: Context<Initialize>, input_one: String) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(input_one: String, input_two: String)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should report error for too many parameters
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
+        assert!(diagnostics[0].message.contains("input_two"));
+        assert!(diagnostics[0].message.contains("not found in handler"));
+    }
+
+    #[test]
+    fn test_no_instruction_attribute() {
+        let mut detector = InstructionAttributeInvalidDetector::default();
+        
+        let code = r#"
+#[program]
+pub mod example {
+    use super::*;
+    
+    pub fn initialize(ctx: Context<Initialize>, input_one: String) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should be no diagnostics when no instruction attribute is present
+        assert_eq!(diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_non_accounts_struct() {
+        let mut detector = InstructionAttributeInvalidDetector::default();
+        
+        let code = r#"
+#[program]
+pub mod example {
+    use super::*;
+    
+    pub fn initialize(ctx: Context<Initialize>, input_one: String) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[instruction(input_one: String)]
+pub struct SomeOtherStruct {
+    pub field: String,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should be no diagnostics for non-Accounts structs
+        assert_eq!(diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_no_matching_handler() {
+        let mut detector = InstructionAttributeInvalidDetector::default();
+        
+        let code = r#"
+#[program]
+pub mod example {
+    use super::*;
+    
+    pub fn other_function(ctx: Context<Initialize>, input_one: String) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(input_one: String)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should be no diagnostics when no matching handler is found
+        assert_eq!(diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_mixed_valid_invalid_params() {
+        let mut detector = InstructionAttributeInvalidDetector::default();
+        
+        let code = r#"
+#[program]
+pub mod example {
+    use super::*;
+    
+    pub fn initialize(ctx: Context<Initialize>, input_one: String, input_two: String, input_three: bool) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(input_one: String, input_three: bool)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should report error for wrong parameter order (input_three should be after input_two)
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
+        assert!(diagnostics[0].message.contains("input_three"));
+        assert!(diagnostics[0].message.contains("input_two"));
+    }
+
+    #[test]
+    fn test_invalid_instruction_attribute_type_mismatch() {
+        let mut detector = InstructionAttributeInvalidDetector::default();
+        
+        let code = r#"
+#[program]
+pub mod example {
+    use super::*;
+    
+    pub fn initialize(ctx: Context<Initialize>, data: u8, text: u8) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(data: u64, text: bool)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should report errors for type mismatches
+        assert_eq!(diagnostics.len(), 2);
+        
+        // Check first error (data: u64 vs u8)
+        assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
+        assert!(diagnostics[0].message.contains("data"));
+        assert!(diagnostics[0].message.contains("u64"));
+        assert!(diagnostics[0].message.contains("u8"));
+        
+        // Check second error (text: bool vs u8)
+        assert_eq!(diagnostics[1].severity, Some(DiagnosticSeverity::ERROR));
+        assert!(diagnostics[1].message.contains("text"));
+        assert!(diagnostics[1].message.contains("bool"));
+        assert!(diagnostics[1].message.contains("u8"));
+    }
+
+    #[test]
+    fn test_valid_instruction_attribute_matching_types() {
+        let mut detector = InstructionAttributeInvalidDetector::default();
+        
+        let code = r#"
+#[program]
+pub mod example {
+    use super::*;
+    
+    pub fn initialize(ctx: Context<Initialize>, data: u8, text: bool) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(data: u8, text: bool)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should be no diagnostics for matching types
+        assert_eq!(diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_different_function_name_than_context() {
+        let mut detector = InstructionAttributeInvalidDetector::default();
+        
+        let code = r#"
+#[program]
+pub mod example {
+    use super::*;
+    
+    pub fn create_user(ctx: Context<Initialize>, user_name: String, user_age: u8) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(user_name: String, user_age: u8)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should be no diagnostics - function name is different but Context<Initialize> matches
+        assert_eq!(diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_different_function_name_with_type_mismatch() {
+        let mut detector = InstructionAttributeInvalidDetector::default();
+        
+        let code = r#"
+#[program]
+pub mod example {
+    use super::*;
+    
+    pub fn create_user(ctx: Context<Initialize>, user_name: String, user_age: u8) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(user_name: String, user_age: u64)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should report type mismatch for user_age (u64 vs u8)
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
+        assert!(diagnostics[0].message.contains("user_age"));
+        assert!(diagnostics[0].message.contains("u64"));
+        assert!(diagnostics[0].message.contains("u8"));
+    }
+} 

--- a/language-server/tests/instruction_attribute_invalid_test.rs
+++ b/language-server/tests/instruction_attribute_invalid_test.rs
@@ -1,13 +1,13 @@
 #[cfg(test)]
 mod tests {
-    use language_server::core::detectors::instruction_attribute_invalid::InstructionAttributeInvalidDetector;
     use language_server::core::detectors::detector::Detector;
+    use language_server::core::detectors::instruction_attribute_invalid::InstructionAttributeInvalidDetector;
     use tower_lsp::lsp_types::DiagnosticSeverity;
 
     #[test]
     fn test_valid_instruction_attribute_same_order() {
         let mut detector = InstructionAttributeInvalidDetector::default();
-        
+
         let code = r#"
 #[program]
 pub mod example {
@@ -28,7 +28,7 @@ pub struct Initialize<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should be no diagnostics for valid usage
         assert_eq!(diagnostics.len(), 0);
     }
@@ -36,7 +36,7 @@ pub struct Initialize<'info> {
     #[test]
     fn test_valid_instruction_attribute_partial_params() {
         let mut detector = InstructionAttributeInvalidDetector::default();
-        
+
         let code = r#"
 #[program]
 pub mod example {
@@ -57,7 +57,7 @@ pub struct Initialize<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should be no diagnostics for valid partial usage
         assert_eq!(diagnostics.len(), 0);
     }
@@ -65,7 +65,7 @@ pub struct Initialize<'info> {
     #[test]
     fn test_invalid_instruction_attribute_wrong_order() {
         let mut detector = InstructionAttributeInvalidDetector::default();
-        
+
         let code = r#"
 #[program]
 pub mod example {
@@ -86,7 +86,7 @@ pub struct Initialize<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should report error for wrong parameter order
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
@@ -98,7 +98,7 @@ pub struct Initialize<'info> {
     #[test]
     fn test_invalid_instruction_attribute_too_many_params() {
         let mut detector = InstructionAttributeInvalidDetector::default();
-        
+
         let code = r#"
 #[program]
 pub mod example {
@@ -119,7 +119,7 @@ pub struct Initialize<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should report error for too many parameters
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
@@ -130,7 +130,7 @@ pub struct Initialize<'info> {
     #[test]
     fn test_no_instruction_attribute() {
         let mut detector = InstructionAttributeInvalidDetector::default();
-        
+
         let code = r#"
 #[program]
 pub mod example {
@@ -150,7 +150,7 @@ pub struct Initialize<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should be no diagnostics when no instruction attribute is present
         assert_eq!(diagnostics.len(), 0);
     }
@@ -158,7 +158,7 @@ pub struct Initialize<'info> {
     #[test]
     fn test_non_accounts_struct() {
         let mut detector = InstructionAttributeInvalidDetector::default();
-        
+
         let code = r#"
 #[program]
 pub mod example {
@@ -176,7 +176,7 @@ pub struct SomeOtherStruct {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should be no diagnostics for non-Accounts structs
         assert_eq!(diagnostics.len(), 0);
     }
@@ -184,7 +184,7 @@ pub struct SomeOtherStruct {
     #[test]
     fn test_no_matching_handler() {
         let mut detector = InstructionAttributeInvalidDetector::default();
-        
+
         let code = r#"
 #[program]
 pub mod example {
@@ -205,7 +205,7 @@ pub struct Initialize<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should be no diagnostics when no matching handler is found
         assert_eq!(diagnostics.len(), 0);
     }
@@ -213,7 +213,7 @@ pub struct Initialize<'info> {
     #[test]
     fn test_mixed_valid_invalid_params() {
         let mut detector = InstructionAttributeInvalidDetector::default();
-        
+
         let code = r#"
 #[program]
 pub mod example {
@@ -234,7 +234,7 @@ pub struct Initialize<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should report error for wrong parameter order (input_three should be after input_two)
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
@@ -245,7 +245,7 @@ pub struct Initialize<'info> {
     #[test]
     fn test_invalid_instruction_attribute_type_mismatch() {
         let mut detector = InstructionAttributeInvalidDetector::default();
-        
+
         let code = r#"
 #[program]
 pub mod example {
@@ -266,16 +266,16 @@ pub struct Initialize<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should report errors for type mismatches
         assert_eq!(diagnostics.len(), 2);
-        
+
         // Check first error (data: u64 vs u8)
         assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
         assert!(diagnostics[0].message.contains("data"));
         assert!(diagnostics[0].message.contains("u64"));
         assert!(diagnostics[0].message.contains("u8"));
-        
+
         // Check second error (text: bool vs u8)
         assert_eq!(diagnostics[1].severity, Some(DiagnosticSeverity::ERROR));
         assert!(diagnostics[1].message.contains("text"));
@@ -286,7 +286,7 @@ pub struct Initialize<'info> {
     #[test]
     fn test_valid_instruction_attribute_matching_types() {
         let mut detector = InstructionAttributeInvalidDetector::default();
-        
+
         let code = r#"
 #[program]
 pub mod example {
@@ -307,7 +307,7 @@ pub struct Initialize<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should be no diagnostics for matching types
         assert_eq!(diagnostics.len(), 0);
     }
@@ -315,7 +315,7 @@ pub struct Initialize<'info> {
     #[test]
     fn test_different_function_name_than_context() {
         let mut detector = InstructionAttributeInvalidDetector::default();
-        
+
         let code = r#"
 #[program]
 pub mod example {
@@ -336,7 +336,7 @@ pub struct Initialize<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should be no diagnostics - function name is different but Context<Initialize> matches
         assert_eq!(diagnostics.len(), 0);
     }
@@ -344,7 +344,7 @@ pub struct Initialize<'info> {
     #[test]
     fn test_different_function_name_with_type_mismatch() {
         let mut detector = InstructionAttributeInvalidDetector::default();
-        
+
         let code = r#"
 #[program]
 pub mod example {
@@ -365,7 +365,7 @@ pub struct Initialize<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should report type mismatch for user_age (u64 vs u8)
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
@@ -373,4 +373,4 @@ pub struct Initialize<'info> {
         assert!(diagnostics[0].message.contains("u64"));
         assert!(diagnostics[0].message.contains("u8"));
     }
-} 
+}

--- a/language-server/tests/instruction_attribute_unused_test.rs
+++ b/language-server/tests/instruction_attribute_unused_test.rs
@@ -1,13 +1,13 @@
 #[cfg(test)]
 mod tests {
-    use language_server::core::detectors::instruction_attribute_unused::InstructionAttributeUnusedDetector;
     use language_server::core::detectors::detector::Detector;
+    use language_server::core::detectors::instruction_attribute_unused::InstructionAttributeUnusedDetector;
     use tower_lsp::lsp_types::DiagnosticSeverity;
 
     #[test]
     fn test_detects_unused_instruction_parameter() {
         let mut detector = InstructionAttributeUnusedDetector::default();
-        
+
         let code = r#"
 #[derive(Accounts)]
 #[instruction(data_2: u8, parameter2: String, parameter1237y012: bool)]
@@ -23,15 +23,15 @@ pub struct Initialize<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // All three parameters should be reported as unused
         assert_eq!(diagnostics.len(), 3);
-        
+
         // Check that all diagnostics are warnings
         for diagnostic in &diagnostics {
             assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::WARNING));
         }
-        
+
         // Check that the messages contain the parameter names
         let messages: Vec<String> = diagnostics.iter().map(|d| d.message.clone()).collect();
         assert!(messages.iter().any(|msg| msg.contains("data_2")));
@@ -42,7 +42,7 @@ pub struct Initialize<'info> {
     #[test]
     fn test_detects_used_instruction_parameter_in_seeds() {
         let mut detector = InstructionAttributeUnusedDetector::default();
-        
+
         let code = r#"
 #[derive(Accounts)]
 #[instruction(seed_value: u8)]
@@ -56,7 +56,7 @@ pub struct Initialize<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // seed_value is used in seeds, so no diagnostic should be reported
         assert_eq!(diagnostics.len(), 0);
     }
@@ -64,7 +64,7 @@ pub struct Initialize<'info> {
     #[test]
     fn test_detects_used_instruction_parameter_in_space() {
         let mut detector = InstructionAttributeUnusedDetector::default();
-        
+
         let code = r#"
 #[derive(Accounts)]
 #[instruction(data_size: usize)]
@@ -78,7 +78,7 @@ pub struct Initialize<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // data_size is used in space calculation, so no diagnostic should be reported
         assert_eq!(diagnostics.len(), 0);
     }
@@ -86,7 +86,7 @@ pub struct Initialize<'info> {
     #[test]
     fn test_detects_used_instruction_parameter_in_constraints() {
         let mut detector = InstructionAttributeUnusedDetector::default();
-        
+
         let code = r#"
 #[derive(Accounts)]
 #[instruction(expected_value: u64)]
@@ -100,7 +100,7 @@ pub struct Initialize<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // expected_value is used in constraint, so no diagnostic should be reported
         assert_eq!(diagnostics.len(), 0);
     }
@@ -108,7 +108,7 @@ pub struct Initialize<'info> {
     #[test]
     fn test_mixed_used_and_unused_parameters() {
         let mut detector = InstructionAttributeUnusedDetector::default();
-        
+
         let code = r#"
 #[derive(Accounts)]
 #[instruction(used_param: u8, unused_param: String)]
@@ -122,7 +122,7 @@ pub struct Initialize<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Only unused_param should be reported
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0].message.contains("unused_param"));
@@ -131,7 +131,7 @@ pub struct Initialize<'info> {
     #[test]
     fn test_no_instruction_attribute() {
         let mut detector = InstructionAttributeUnusedDetector::default();
-        
+
         let code = r#"
 #[derive(Accounts)]
 pub struct Initialize<'info> {
@@ -144,7 +144,7 @@ pub struct Initialize<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // No instruction attribute, so no diagnostics should be reported
         assert_eq!(diagnostics.len(), 0);
     }
@@ -152,7 +152,7 @@ pub struct Initialize<'info> {
     #[test]
     fn test_non_accounts_struct() {
         let mut detector = InstructionAttributeUnusedDetector::default();
-        
+
         let code = r#"
 #[instruction(param: u8)]
 pub struct SomeOtherStruct {
@@ -161,8 +161,8 @@ pub struct SomeOtherStruct {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Not an Accounts struct, so no diagnostics should be reported
         assert_eq!(diagnostics.len(), 0);
     }
-} 
+}

--- a/language-server/tests/instruction_attribute_unused_test.rs
+++ b/language-server/tests/instruction_attribute_unused_test.rs
@@ -1,0 +1,168 @@
+#[cfg(test)]
+mod tests {
+    use language_server::core::detectors::instruction_attribute_unused::InstructionAttributeUnusedDetector;
+    use language_server::core::detectors::detector::Detector;
+    use tower_lsp::lsp_types::DiagnosticSeverity;
+
+    #[test]
+    fn test_detects_unused_instruction_parameter() {
+        let mut detector = InstructionAttributeUnusedDetector::default();
+        
+        let code = r#"
+#[derive(Accounts)]
+#[instruction(data_2: u8, parameter2: String, parameter1237y012: bool)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    #[account(init, payer = signer, space = 8 + 32, seeds = [b"hello"], bump)]
+    pub account: Account<'info, TestAccount>,
+    /// CHECK: ok
+    pub program: AccountInfo<'info>,
+    pub system_program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // All three parameters should be reported as unused
+        assert_eq!(diagnostics.len(), 3);
+        
+        // Check that all diagnostics are warnings
+        for diagnostic in &diagnostics {
+            assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::WARNING));
+        }
+        
+        // Check that the messages contain the parameter names
+        let messages: Vec<String> = diagnostics.iter().map(|d| d.message.clone()).collect();
+        assert!(messages.iter().any(|msg| msg.contains("data_2")));
+        assert!(messages.iter().any(|msg| msg.contains("parameter2")));
+        assert!(messages.iter().any(|msg| msg.contains("parameter1237y012")));
+    }
+
+    #[test]
+    fn test_detects_used_instruction_parameter_in_seeds() {
+        let mut detector = InstructionAttributeUnusedDetector::default();
+        
+        let code = r#"
+#[derive(Accounts)]
+#[instruction(seed_value: u8)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    #[account(init, payer = signer, space = 8 + 32, seeds = [b"hello", seed_value.to_le_bytes().as_ref()], bump)]
+    pub account: Account<'info, TestAccount>,
+    pub system_program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // seed_value is used in seeds, so no diagnostic should be reported
+        assert_eq!(diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_detects_used_instruction_parameter_in_space() {
+        let mut detector = InstructionAttributeUnusedDetector::default();
+        
+        let code = r#"
+#[derive(Accounts)]
+#[instruction(data_size: usize)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    #[account(init, payer = signer, space = 8 + data_size)]
+    pub account: Account<'info, TestAccount>,
+    pub system_program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // data_size is used in space calculation, so no diagnostic should be reported
+        assert_eq!(diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_detects_used_instruction_parameter_in_constraints() {
+        let mut detector = InstructionAttributeUnusedDetector::default();
+        
+        let code = r#"
+#[derive(Accounts)]
+#[instruction(expected_value: u64)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    #[account(init, payer = signer, space = 8 + 32, constraint = account.value == expected_value)]
+    pub account: Account<'info, TestAccount>,
+    pub system_program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // expected_value is used in constraint, so no diagnostic should be reported
+        assert_eq!(diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_mixed_used_and_unused_parameters() {
+        let mut detector = InstructionAttributeUnusedDetector::default();
+        
+        let code = r#"
+#[derive(Accounts)]
+#[instruction(used_param: u8, unused_param: String)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    #[account(init, payer = signer, space = 8 + 32, seeds = [b"hello", used_param.to_le_bytes().as_ref()], bump)]
+    pub account: Account<'info, TestAccount>,
+    pub system_program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Only unused_param should be reported
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].message.contains("unused_param"));
+    }
+
+    #[test]
+    fn test_no_instruction_attribute() {
+        let mut detector = InstructionAttributeUnusedDetector::default();
+        
+        let code = r#"
+#[derive(Accounts)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    #[account(init, payer = signer, space = 8 + 32)]
+    pub account: Account<'info, TestAccount>,
+    pub system_program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // No instruction attribute, so no diagnostics should be reported
+        assert_eq!(diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_non_accounts_struct() {
+        let mut detector = InstructionAttributeUnusedDetector::default();
+        
+        let code = r#"
+#[instruction(param: u8)]
+pub struct SomeOtherStruct {
+    pub field: u8,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Not an Accounts struct, so no diagnostics should be reported
+        assert_eq!(diagnostics.len(), 0);
+    }
+} 

--- a/language-server/tests/missing_check_comment_test.rs
+++ b/language-server/tests/missing_check_comment_test.rs
@@ -1,0 +1,212 @@
+#[cfg(test)]
+mod tests {
+    use language_server::core::detectors::missing_check_comment::MissingCheckCommentDetector;
+    use language_server::core::detectors::detector::Detector;
+    use tower_lsp::lsp_types::DiagnosticSeverity;
+
+    #[test]
+    fn test_missing_check_comment_accountinfo() {
+        let mut detector = MissingCheckCommentDetector::default();
+        
+        let code = r#"
+#[derive(Accounts)]
+pub struct InstructionAccounts<'info> {
+    pub unchecked_account: AccountInfo<'info>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should report error for missing CHECK comment
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
+        assert!(diagnostics[0].message.contains("Missing /// CHECK:"));
+        assert!(diagnostics[0].message.contains("unchecked_account"));
+        assert!(diagnostics[0].message.contains("AccountInfo"));
+    }
+
+    #[test]
+    fn test_missing_check_comment_unchecked_account() {
+        let mut detector = MissingCheckCommentDetector::default();
+        
+        let code = r#"
+#[derive(Accounts)]
+pub struct InstructionAccounts<'info> {
+    pub account: UncheckedAccount<'info>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should report error for missing CHECK comment
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
+        assert!(diagnostics[0].message.contains("Missing /// CHECK:"));
+        assert!(diagnostics[0].message.contains("account"));
+        assert!(diagnostics[0].message.contains("UncheckedAccount"));
+    }
+
+    #[test]
+    fn test_valid_check_comment_accountinfo() {
+        let mut detector = MissingCheckCommentDetector::default();
+        
+        let code = r#"
+#[derive(Accounts)]
+pub struct InstructionAccounts<'info> {
+    /// CHECK: AccountInfo is an unchecked account
+    pub unchecked_account: AccountInfo<'info>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should be no diagnostics for valid CHECK comment
+        assert_eq!(diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_valid_check_comment_unchecked_account() {
+        let mut detector = MissingCheckCommentDetector::default();
+        
+        let code = r#"
+#[derive(Accounts)]
+pub struct InstructionAccounts<'info> {
+    /// CHECK: No checks are performed
+    pub account: UncheckedAccount<'info>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should be no diagnostics for valid CHECK comment
+        assert_eq!(diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_multiple_unchecked_accounts() {
+        let mut detector = MissingCheckCommentDetector::default();
+        
+        let code = r#"
+#[derive(Accounts)]
+pub struct InstructionAccounts<'info> {
+    /// CHECK: This is properly documented
+    pub valid_account: AccountInfo<'info>,
+    
+    pub missing_check1: AccountInfo<'info>,
+    pub missing_check2: UncheckedAccount<'info>,
+    
+    /// CHECK: Another valid one
+    pub valid_unchecked: UncheckedAccount<'info>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should report errors for the two missing CHECK comments
+        assert_eq!(diagnostics.len(), 2);
+        
+        // Check first error
+        assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
+        assert!(diagnostics[0].message.contains("missing_check1"));
+        
+        // Check second error
+        assert_eq!(diagnostics[1].severity, Some(DiagnosticSeverity::ERROR));
+        assert!(diagnostics[1].message.contains("missing_check2"));
+    }
+
+    #[test]
+    fn test_regular_doc_comment_not_check() {
+        let mut detector = MissingCheckCommentDetector::default();
+        
+        let code = r#"
+#[derive(Accounts)]
+pub struct InstructionAccounts<'info> {
+    /// This is just a regular doc comment
+    pub unchecked_account: AccountInfo<'info>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should report error because it's not a CHECK comment
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
+        assert!(diagnostics[0].message.contains("Missing /// CHECK:"));
+    }
+
+    #[test]
+    fn test_other_account_types_ignored() {
+        let mut detector = MissingCheckCommentDetector::default();
+        
+        let code = r#"
+#[derive(Accounts)]
+pub struct InstructionAccounts<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    
+    pub account: Account<'info, MyAccount>,
+    
+    pub program: Program<'info, System>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should be no diagnostics for other account types
+        assert_eq!(diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_non_accounts_struct_ignored() {
+        let mut detector = MissingCheckCommentDetector::default();
+        
+        let code = r#"
+pub struct SomeOtherStruct<'info> {
+    pub unchecked_account: AccountInfo<'info>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should be no diagnostics for non-Accounts structs
+        assert_eq!(diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_check_comment_with_extra_text() {
+        let mut detector = MissingCheckCommentDetector::default();
+        
+        let code = r#"
+#[derive(Accounts)]
+pub struct InstructionAccounts<'info> {
+    /// CHECK: This account is used for cross-program invocation and is validated by the target program
+    pub unchecked_account: AccountInfo<'info>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should be no diagnostics for detailed CHECK comment
+        assert_eq!(diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn test_multiline_check_comment() {
+        let mut detector = MissingCheckCommentDetector::default();
+        
+        let code = r#"
+#[derive(Accounts)]
+pub struct InstructionAccounts<'info> {
+    /// CHECK: This account is safe because:
+    /// - It's only used for reading data
+    /// - The program validates it internally
+    pub unchecked_account: AccountInfo<'info>,
+}
+"#;
+
+        let diagnostics = detector.analyze(code, None);
+        
+        // Should be no diagnostics for multiline CHECK comment
+        assert_eq!(diagnostics.len(), 0);
+    }
+} 

--- a/language-server/tests/missing_check_comment_test.rs
+++ b/language-server/tests/missing_check_comment_test.rs
@@ -1,13 +1,13 @@
 #[cfg(test)]
 mod tests {
-    use language_server::core::detectors::missing_check_comment::MissingCheckCommentDetector;
     use language_server::core::detectors::detector::Detector;
+    use language_server::core::detectors::missing_check_comment::MissingCheckCommentDetector;
     use tower_lsp::lsp_types::DiagnosticSeverity;
 
     #[test]
     fn test_missing_check_comment_accountinfo() {
         let mut detector = MissingCheckCommentDetector::default();
-        
+
         let code = r#"
 #[derive(Accounts)]
 pub struct InstructionAccounts<'info> {
@@ -16,7 +16,7 @@ pub struct InstructionAccounts<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should report error for missing CHECK comment
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
@@ -28,7 +28,7 @@ pub struct InstructionAccounts<'info> {
     #[test]
     fn test_missing_check_comment_unchecked_account() {
         let mut detector = MissingCheckCommentDetector::default();
-        
+
         let code = r#"
 #[derive(Accounts)]
 pub struct InstructionAccounts<'info> {
@@ -37,7 +37,7 @@ pub struct InstructionAccounts<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should report error for missing CHECK comment
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
@@ -49,7 +49,7 @@ pub struct InstructionAccounts<'info> {
     #[test]
     fn test_valid_check_comment_accountinfo() {
         let mut detector = MissingCheckCommentDetector::default();
-        
+
         let code = r#"
 #[derive(Accounts)]
 pub struct InstructionAccounts<'info> {
@@ -59,7 +59,7 @@ pub struct InstructionAccounts<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should be no diagnostics for valid CHECK comment
         assert_eq!(diagnostics.len(), 0);
     }
@@ -67,7 +67,7 @@ pub struct InstructionAccounts<'info> {
     #[test]
     fn test_valid_check_comment_unchecked_account() {
         let mut detector = MissingCheckCommentDetector::default();
-        
+
         let code = r#"
 #[derive(Accounts)]
 pub struct InstructionAccounts<'info> {
@@ -77,7 +77,7 @@ pub struct InstructionAccounts<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should be no diagnostics for valid CHECK comment
         assert_eq!(diagnostics.len(), 0);
     }
@@ -85,7 +85,7 @@ pub struct InstructionAccounts<'info> {
     #[test]
     fn test_multiple_unchecked_accounts() {
         let mut detector = MissingCheckCommentDetector::default();
-        
+
         let code = r#"
 #[derive(Accounts)]
 pub struct InstructionAccounts<'info> {
@@ -101,14 +101,14 @@ pub struct InstructionAccounts<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should report errors for the two missing CHECK comments
         assert_eq!(diagnostics.len(), 2);
-        
+
         // Check first error
         assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
         assert!(diagnostics[0].message.contains("missing_check1"));
-        
+
         // Check second error
         assert_eq!(diagnostics[1].severity, Some(DiagnosticSeverity::ERROR));
         assert!(diagnostics[1].message.contains("missing_check2"));
@@ -117,7 +117,7 @@ pub struct InstructionAccounts<'info> {
     #[test]
     fn test_regular_doc_comment_not_check() {
         let mut detector = MissingCheckCommentDetector::default();
-        
+
         let code = r#"
 #[derive(Accounts)]
 pub struct InstructionAccounts<'info> {
@@ -127,7 +127,7 @@ pub struct InstructionAccounts<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should report error because it's not a CHECK comment
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
@@ -137,7 +137,7 @@ pub struct InstructionAccounts<'info> {
     #[test]
     fn test_other_account_types_ignored() {
         let mut detector = MissingCheckCommentDetector::default();
-        
+
         let code = r#"
 #[derive(Accounts)]
 pub struct InstructionAccounts<'info> {
@@ -151,7 +151,7 @@ pub struct InstructionAccounts<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should be no diagnostics for other account types
         assert_eq!(diagnostics.len(), 0);
     }
@@ -159,7 +159,7 @@ pub struct InstructionAccounts<'info> {
     #[test]
     fn test_non_accounts_struct_ignored() {
         let mut detector = MissingCheckCommentDetector::default();
-        
+
         let code = r#"
 pub struct SomeOtherStruct<'info> {
     pub unchecked_account: AccountInfo<'info>,
@@ -167,7 +167,7 @@ pub struct SomeOtherStruct<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should be no diagnostics for non-Accounts structs
         assert_eq!(diagnostics.len(), 0);
     }
@@ -175,7 +175,7 @@ pub struct SomeOtherStruct<'info> {
     #[test]
     fn test_check_comment_with_extra_text() {
         let mut detector = MissingCheckCommentDetector::default();
-        
+
         let code = r#"
 #[derive(Accounts)]
 pub struct InstructionAccounts<'info> {
@@ -185,7 +185,7 @@ pub struct InstructionAccounts<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should be no diagnostics for detailed CHECK comment
         assert_eq!(diagnostics.len(), 0);
     }
@@ -193,7 +193,7 @@ pub struct InstructionAccounts<'info> {
     #[test]
     fn test_multiline_check_comment() {
         let mut detector = MissingCheckCommentDetector::default();
-        
+
         let code = r#"
 #[derive(Accounts)]
 pub struct InstructionAccounts<'info> {
@@ -205,8 +205,8 @@ pub struct InstructionAccounts<'info> {
 "#;
 
         let diagnostics = detector.analyze(code, None);
-        
+
         // Should be no diagnostics for multiline CHECK comment
         assert_eq!(diagnostics.len(), 0);
     }
-} 
+}


### PR DESCRIPTION
## Description

Added 3 detectors:

- invalid instruction attribute parameters
- unused instruction attribute parameters
- no check doc comment above accountinfo and unchecked account types

<!--
Write a description of your pull request.
-->

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

- [ ] I clicked on "Allow edits from maintainers"
