### PR TITLE
Skip .anchor directory that shouldn't be scanned

### DIFF
--- a/language-server/src/core/file_scanner/scanner.rs
+++ b/language-server/src/core/file_scanner/scanner.rs
@@ -222,7 +222,7 @@ impl FileScanner {
                 if let Some(dir_name) = path.file_name().and_then(|n| n.to_str()) {
                     if matches!(
                         dir_name,
-                        "target" | "node_modules" | ".git" | ".vscode" | "out"
+                        "target" | "node_modules" | ".git" | ".vscode" | "out" | ".anchor"
                     ) {
                         continue;
                     }


### PR DESCRIPTION
## Skip .anchor directory that shouldn't be scanned

There is no need to scan this directory, as it may contain only auxiliary files or temporary rs files in the ".anchor/expanded-macros/*" directories, which are generated after running the "anchor expand" command. Excluding this directory from the list of scanned ones will also speed up the scan.
